### PR TITLE
V0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ public class DialogueLoop extends AbstractLoop {
 ### Web API
 
 - The entire game can also be played via a web API - see [How to use the API](docs/HOW_TO_API.md) for details
-- You can also find a web interface here: [Procedural Generation 1 Frontend](https://github.com/kimgoetzke/procedural-generation-1-front-end)
+- You can also find a web interface
+  here: [Procedural Generation 1 Frontend](https://github.com/kimgoetzke/procedural-generation-1-front-end)
 
 ### Other technical features
 
@@ -120,11 +121,11 @@ interface, it is rather tedious to use.
 
 ### CLI: Jar
 
-Clone and build project, and run JAR with `cli-prod` profile:
+Clone and build project. Then run JAR with `cli-prod` profile:
 
 ```shell
 cd build\libs 
-java -jar -D"spring.profiles.active"=cli-prod procedural_generation_1-0.3.jar
+java -jar -D"spring.profiles.active"=cli-prod procedural_generation_1-0.4.jar
 ```
 
 ### CLI: IDE
@@ -134,7 +135,8 @@ Clone project and run `Application.main` with `-Dspring.profiles.active=cli-prod
 
 ### Web API
 
-See [How to use the API](docs/HOW_TO_API.md). A Postman collection is available, too.
+See [How to use the API](docs/HOW_TO_API.md). A Postman collection is available in `/docs`. A web interface can be found
+in [this repository](https://github.com/kimgoetzke/procedural-generation-1-front-end).
 
 ## Other notes
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ public class DialogueLoop extends AbstractLoop {
 ### Web API
 
 - The entire game can also be played via a web API - see [How to use the API](docs/HOW_TO_API.md) for details
+- You can also find a web interface here: [Procedural Generation 1 Frontend](https://github.com/kimgoetzke/procedural-generation-1-front-end)
 
 ### Other technical features
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,17 @@ following:
 - [How to create event YAML files](docs/HOW_TO_YAML_EVENTS.md)
 - [How to use the API](docs/HOW_TO_API.md)
 
-### Random ideas for further development
+### Limitations & some ideas for further development
 
+- **Before developing major new features**:
+    - Refactor the code related to how events work as it's too fiddly to build on it right now - considering:
+        - What kind of events should be shown (multiple vs only one at a time)?
+        - Should locations be visible if there's no event (or other activity) there?
+        - What should determine the kind of event generated for an NPC?
+    - Add chance to be attacked while travelling
 - **User interface**:
-    - Implement a web interface to use the API
     - Add visual mini-map for both CLI (using ASCII art) and web
+    - Use an LLM to auto-generate background images for each view in the web interface
 - **Procedural generation**:
     - Implement biomes which:
         - Determine difficulty of events, attitude towards player, etc. based on environmental factors

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.hindsight'
-version = '0.3'
+version = '0.4'
 
 java {
     sourceCompatibility = '19'

--- a/docs/HOW_TO_API.md
+++ b/docs/HOW_TO_API.md
@@ -2,9 +2,19 @@
 
 Endpoints require basic auth. Use `player1` / `password` or `player2` / `password`.
 
+Please see [Procedural Generation 1 Frontend](https://github.com/kimgoetzke/procedural-generation-1-front-end) for a
+sample web interface using this API.
+
+## Limitations
+
+1. Authentication has not been implemented yet. Currently, the game uses hardcoded credentials
+   for `player1` & `player2`.
+2. The API does not handle player deaths yet.
+3. There are no API-specific acceptance/integration tests yet.
+
 ## Endpoints
 
-### `GET` `/api/play`
+### Start new game with `GET` `/api/play`
 
 - Requires basic auth
 - Returns a JSON `WebResponse` containing the `List<ActionResponseDto>` and `PlayerDto`
@@ -14,7 +24,17 @@ Endpoints require basic auth. Use `player1` / `password` or `player2` / `passwor
 curl -u player1:password http://localhost:8080/api/play
 ```
 
-### `POST` `/api/play`
+### Resume active game with `GET` `/api/play/{playerId}`
+
+- Requires basic auth
+- Returns a JSON `WebResponse` containing the `viewType` to be rendered and the relevant DTO(s)
+- Example request:
+
+```
+curl -u player1:password http://localhost:8080/api/play/PLA~PLAYER1@1277912753
+```
+
+### Play active game with `POST` `/api/play`
 
 - Requires basic auth
 - Returns a JSON `WebResponse` containing the `viewType` to be rendered and the relevant DTO(s)
@@ -34,7 +54,7 @@ curl -u player1:password -X POST http://localhost:8080/api/play -H "Content-Type
 }
 ```
 
-### `GET` `/api/play/{playerId}/quest-log`
+### Get active quests with `GET` `/api/play/{playerId}/quest-log`
 
 - Requires basic auth
 - Returns a JSON `List<QuestDto>`

--- a/docs/HOW_TO_API.md
+++ b/docs/HOW_TO_API.md
@@ -7,10 +7,11 @@ sample web interface using this API.
 
 ## Limitations
 
-1. Authentication has not been implemented yet. Currently, the game uses hardcoded credentials
-   for `player1` & `player2`.
-2. The API does not handle player deaths yet.
-3. There are no API-specific acceptance/integration tests yet.
+1. Authentication has not been implemented yet. Currently, the game only allows for the hardcoded credentials
+   for `player1` & `player2` (see above).
+2. There are no API-specific tests yet. This is because the API was only created to have _something_ to use for a
+   frontend project (i.e. so that I have something I can use when creating a frontend application to improve my
+   frontend skills).
 
 ## Endpoints
 

--- a/docs/procedural-generation-1.postman_collection.json
+++ b/docs/procedural-generation-1.postman_collection.json
@@ -15,7 +15,8 @@
 						"exec": [
 							"let response = pm.response.json();\r",
 							"player = response.player;\r",
-							"pm.collectionVariables.set(\"player1Id\", player.id);"
+							"pm.collectionVariables.set(\"player1Id\", player.id);\r",
+							"pm.collectionVariables.set(\"player1Name\", player.name);"
 						],
 						"type": "text/javascript"
 					}
@@ -34,6 +35,40 @@
 					"path": [
 						"api",
 						"play"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Resume",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let response = pm.response.json();\r",
+							"player = response.player;\r",
+							"pm.collectionVariables.set(\"player1Id\", player.id);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/api/play/{{player1Id}}",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"play",
+						"{{player1Id}}"
 					]
 				}
 			},
@@ -140,6 +175,10 @@
 	"variable": [
 		{
 			"key": "player1Id",
+			"value": ""
+		},
+		{
+			"key": "player1Name",
 			"value": ""
 		}
 	]

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/action/ActionHandler.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/action/ActionHandler.java
@@ -74,7 +74,7 @@ public class ActionHandler {
       if (sequence.isInProgress()) {
         actions.add(af.combatAction(index(actions), "Press on", sequence));
         actions.add(af.stateAction(index(actions), "Retreat (for now)", AT_POI));
-      } else {
+      } else if (player.getHealth() > 0) {
         actions.add(af.stateAction(index(actions), "Return victoriously", AT_POI));
       }
     }
@@ -96,6 +96,7 @@ public class ActionHandler {
     var visitedLocs = (Runnable) () -> daf.logVisitedLocations(player);
     actions.add(af.locationAction(index(actions), "Resume game", player.getCurrentLocation()));
     actions.add(daf.create(index(actions), "Add 1000 gold", () -> daf.addGold(player)));
+    actions.add(daf.create(index(actions), "Set health to 1 HP", () -> daf.setHealth(player)));
     actions.add(daf.create(index(actions), "Log memory usage", daf::logMemoryStats));
     actions.add(daf.create(index(actions), "Log all locations", daf::logVertices));
     actions.add(daf.create(index(actions), "Log locations inside trigger zone", triggerZone));

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/action/ActionHandler.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/action/ActionHandler.java
@@ -61,6 +61,9 @@ public class ActionHandler {
   public void getDialogueActions(Player player, List<Action> actions) {
     prepend(actions);
     var eventActions = player.getCurrentEvent().getCurrentActions();
+    if (eventActions.isEmpty() && environmentResolver.isNotCli()) {
+      actions.add(af.stateAction(index(actions), "End conversation", AT_POI));
+    }
     addAllActionsFrom(eventActions, actions);
   }
 

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/action/BuyAction.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/action/BuyAction.java
@@ -6,7 +6,7 @@ import static com.hindsight.king_of_castrop_rauxel.configuration.EnvironmentReso
 import com.hindsight.king_of_castrop_rauxel.character.Player;
 import com.hindsight.king_of_castrop_rauxel.cli.CliComponent;
 import com.hindsight.king_of_castrop_rauxel.item.Buyable;
-import com.hindsight.king_of_castrop_rauxel.web.exception.GenericWebException;
+import com.hindsight.king_of_castrop_rauxel.web.exception.InGameException;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -49,7 +49,7 @@ public class BuyAction implements Action {
     var errorMessage = "Not enough gold to buy: '%s'.".formatted(item.getName());
     if (!isBought) {
       nextState(player);
-      throw new GenericWebException(errorMessage);
+      throw new InGameException(errorMessage);
     }
   }
 

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/action/debug/DebugActionFactory.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/action/debug/DebugActionFactory.java
@@ -146,6 +146,11 @@ public class DebugActionFactory {
     log.info("Gifted 1000 gold to player {}", player.getName());
   }
 
+  public void setHealth(Player player) {
+    player.setHealth(1);
+    log.info("Set health of player {} to 1", player.getName());
+  }
+
   public void logLocationsInsideTriggerZone(Player player) {
     var vertices =
         graph.getVertices().stream()

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/character/Player.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/character/Player.java
@@ -30,7 +30,7 @@ public class Player implements Visitor, Combatant {
   private final AppProperties.PlayerProperties playerProperties;
   private final AppProperties.GameProperties gameProperties;
   private int gold;
-  private int health;
+  @Setter private int health;
   private int maxHealth;
   private int experience = 0;
   private int level = 1;
@@ -98,10 +98,6 @@ public class Player implements Visitor, Combatant {
 
   public void changeHealthBy(int health) {
     this.health = Math.max(0, Math.min(maxHealth, this.health + health));
-  }
-
-  public void setHealth(int health) {
-    this.health = health;
   }
 
   public void changeMaxHealthBy(int maxHealth) {

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/game/GameHandler.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/game/GameHandler.java
@@ -1,6 +1,10 @@
 package com.hindsight.king_of_castrop_rauxel.game;
 
+import static com.hindsight.king_of_castrop_rauxel.configuration.EnvironmentResolver.*;
+
 import com.hindsight.king_of_castrop_rauxel.character.Player;
+import com.hindsight.king_of_castrop_rauxel.configuration.EnvironmentResolver;
+import com.hindsight.king_of_castrop_rauxel.event.Event;
 import com.hindsight.king_of_castrop_rauxel.world.Coordinates;
 import com.hindsight.king_of_castrop_rauxel.world.World;
 import lombok.extern.slf4j.Slf4j;
@@ -11,9 +15,11 @@ import org.springframework.stereotype.Component;
 public class GameHandler {
 
   private final World world;
+  private final Environment environment;
 
-  public GameHandler(World world) {
+  public GameHandler(World world, EnvironmentResolver environmentResolver) {
     this.world = world;
+    this.environment = environmentResolver.getEnvironment();
   }
 
   public void updateWorld(Player player) {
@@ -39,7 +45,11 @@ public class GameHandler {
       currentEvent.resetDialogue();
       return;
     }
-    if (!currentEvent.hasNextInteraction()) {
+    updatePlayerStateIfCli(player, currentEvent);
+  }
+
+  private void updatePlayerStateIfCli(Player player, Event currentEvent) {
+    if (environment.equals(Environment.CLI) && !currentEvent.hasNextInteraction()) {
       player.setState(player.getPreviousState());
     }
   }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
@@ -55,6 +55,12 @@ public class Controller {
     log.info("POST /api/play >> Process choice '{}' for: {}", req.getChoice(), req.getPlayerId());
     var webGame = getGameOrThrow(req.getPlayerId(), auth);
     var res = webGame.playGame(req.getChoice());
+    if (res.viewType() == WebResponse.WebViewType.GAME_OVER) {
+      var player = webGame.getPlayer();
+      log.info("Game over for '{}' - removing active game and player", player.getName());
+      playerRepository.deleteById(player.getId());
+      activeGames.remove(webGame);
+    }
     return ResponseEntity.ok(res);
   }
 

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
@@ -28,7 +28,7 @@ public class Controller {
 
   @GetMapping("/api/play")
   public ResponseEntity<WebResponse> start(Authentication auth) {
-    log.info("GET /api/start >> Start game for: {}", auth.getName());
+    log.info("GET /api/play >> Start game for: {}", auth.getName());
     throwIfAlreadyActive(auth);
     var webGame = ctx.getBean(WebGame.class);
     var res = webGame.startGame(auth.getName());
@@ -38,7 +38,7 @@ public class Controller {
 
   @GetMapping("/api/play/{playerId}")
   public ResponseEntity<WebResponse> resume(@PathVariable String playerId, Authentication auth) {
-    log.info("GET /api/start >> Start game for: {}", auth.getName());
+    log.info("GET /api/play/{} >> Resume game for: {}", playerId, auth.getName());
     var player = playerRepository.findById(playerId).orElseThrow(() -> playerNotFound(playerId));
     var activeGame = getGame(player.getId(), auth);
     if (activeGame != null) {

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
@@ -79,9 +79,8 @@ public class Controller {
   }
 
   private WebGame getGame(String playerId, Authentication auth) {
-    var user = auth.getName();
     var game = activeGames.stream().filter(g -> g.getPlayer().getId().equals(playerId)).findFirst();
-    game.ifPresent(webGame -> throwIfForbiddenAccess(playerId, webGame, user));
+    game.ifPresent(webGame -> throwIfForbiddenAccess(playerId, webGame, auth.getName()));
     return game.orElse(null);
   }
 
@@ -92,14 +91,15 @@ public class Controller {
 
   private void throwIfAlreadyActive(Authentication auth) {
     if (playerRepository.findByName(auth.getName()) != null) {
-      throw new GenericWebException("User already has an active game", HttpStatus.CONFLICT);
+      throw new GenericWebException(
+          "User '%s' already has an active game".formatted(auth.getName()), HttpStatus.CONFLICT);
     }
   }
 
-  private static void throwIfGameNotFound(String userName, WebGame game) {
+  private static void throwIfGameNotFound(String playerId, WebGame game) {
     if (game == null) {
       throw new GenericWebException(
-          "User '%s' has no active game".formatted(userName), HttpStatus.NOT_FOUND);
+          "Player '%s' has no active game".formatted(playerId), HttpStatus.NOT_FOUND);
     }
   }
 

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/Controller.java
@@ -1,5 +1,6 @@
 package com.hindsight.king_of_castrop_rauxel.web;
 
+import com.hindsight.king_of_castrop_rauxel.web.dto.PlayerDto;
 import com.hindsight.king_of_castrop_rauxel.web.dto.QuestDto;
 import com.hindsight.king_of_castrop_rauxel.web.dto.WebRequest;
 import com.hindsight.king_of_castrop_rauxel.web.dto.WebResponse;
@@ -7,7 +8,6 @@ import com.hindsight.king_of_castrop_rauxel.web.exception.GenericWebException;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -24,13 +24,32 @@ import org.springframework.web.bind.annotation.*;
 public class Controller {
 
   private final ApplicationContext ctx;
+  private final PlayerRepository playerRepository;
   private final List<WebGame> activeGames = new ArrayList<>();
 
   @GetMapping("/api/play")
   public ResponseEntity<WebResponse> start(Authentication auth) {
     log.info("GET /api/start >> Start game for: {}", auth.getName());
+    if (playerRepository.findByName(auth.getName()) != null) {
+      throw new GenericWebException("User already has an active game", HttpStatus.CONFLICT);
+    }
     var webGame = ctx.getBean(WebGame.class);
     var res = webGame.startGame(auth.getName());
+    activeGames.add(webGame);
+    return ResponseEntity.ok(res);
+  }
+
+  @GetMapping("/api/play/{userName}")
+  public ResponseEntity<WebResponse> resume(@PathVariable String userName, Authentication auth) {
+    log.info("GET /api/start >> Start game for: {}", auth.getName());
+    var player = playerRepository.findByName(userName);
+    throwIfPlayerNotFound(userName, player);
+    var activeGame = getGame(player.getId(), auth);
+    if (activeGame != null) {
+      return ResponseEntity.ok(activeGame.getCurrentGame());
+    }
+    var webGame = ctx.getBean(WebGame.class);
+    var res = webGame.resumeGame(player);
     activeGames.add(webGame);
     return ResponseEntity.ok(res);
   }
@@ -52,21 +71,36 @@ public class Controller {
   }
 
   private WebGame getGameOrThrow(String playerId, Authentication auth) {
+    var game = getGame(playerId, auth);
+    throwIfGameNotFound(playerId, game);
+    return game;
+  }
+
+  private WebGame getGame(String playerId, Authentication auth) {
     var user = auth.getName();
-    var game =
-        activeGames.stream()
-            .filter(g -> g.getPlayer().getId().equals(playerId))
-            .findFirst()
-            .orElseThrow(userNotFound(playerId));
+    var game = activeGames.stream().filter(g -> g.getPlayer().getId().equals(playerId)).findFirst();
+    game.ifPresent(webGame -> throwIfForbiddenAccess(playerId, webGame, user));
+    return game.orElse(null);
+  }
+
+  private static void throwIfPlayerNotFound(String userName, PlayerDto player) {
+    if (player == null) {
+      throw new GenericWebException(
+          "User '%s' does not exist".formatted(userName), HttpStatus.NOT_FOUND);
+    }
+  }
+
+  private static void throwIfGameNotFound(String userName, WebGame game) {
+    if (game == null) {
+      throw new GenericWebException(
+          "User '%s' has no active game".formatted(userName), HttpStatus.CONFLICT);
+    }
+  }
+
+  private static void throwIfForbiddenAccess(String playerId, WebGame game, String user) {
     if (!game.getPlayer().getName().equals(user)) {
       log.warn("User '{}' blocked from accessing game of player '{}'", user, playerId);
       throw new GenericWebException("Action not permitted", HttpStatus.FORBIDDEN);
     }
-    return game;
-  }
-
-  /** User is authenticated but playerId not found. */
-  private Supplier<GenericWebException> userNotFound(String playerId) {
-    return () -> new GenericWebException("Player '%s' does not exist".formatted(playerId));
   }
 }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
@@ -5,6 +5,7 @@ import com.hindsight.king_of_castrop_rauxel.action.ActionHandler;
 import com.hindsight.king_of_castrop_rauxel.character.Player;
 import com.hindsight.king_of_castrop_rauxel.configuration.AppProperties;
 import com.hindsight.king_of_castrop_rauxel.encounter.web.EncounterSummaryDto;
+import com.hindsight.king_of_castrop_rauxel.event.Event;
 import com.hindsight.king_of_castrop_rauxel.game.GameHandler;
 import com.hindsight.king_of_castrop_rauxel.graph.Graph;
 import com.hindsight.king_of_castrop_rauxel.location.Dungeon;
@@ -95,7 +96,15 @@ public class WebGame {
   /** Returns the quest log for the current player without altering the state of the game. */
   public List<QuestDto> getQuests() {
     var allEvents = player.getEvents();
-    return allEvents.stream().map(QuestDto::new).toList();
+    return allEvents.stream()
+        .filter(
+            e -> {
+              var isDialogue = e.getEventDetails().getEventType().equals(Event.Type.DIALOGUE);
+              var isAvailable = e.getEventState() == Event.State.AVAILABLE;
+              return !(isDialogue && isAvailable);
+            })
+        .map(QuestDto::new)
+        .toList();
   }
 
   private static WebResponse getWebResponse(

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
@@ -104,7 +104,11 @@ public class WebGame {
       PlayerDto playerDto,
       List<String> interactions) {
     if (encounterSummary != null) {
-      return new WebResponse(actions, encounterSummary, playerDto);
+      return encounterSummary.isPlayerHasWon()
+          ? new WebResponse(
+              actions, encounterSummary, playerDto, WebResponse.WebViewType.ENCOUNTER_SUMMARY)
+          : new WebResponse(
+              actions, encounterSummary, playerDto, WebResponse.WebViewType.GAME_OVER);
     }
     if (!interactions.isEmpty()) {
       return new WebResponse(actions, interactions, playerDto);

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
@@ -84,6 +84,7 @@ public class WebGame {
     takeAction(choice, actions);
     gameHandler.updateWorld(player);
     var interactions = getInteractions();
+    gameHandler.updateCurrentEventDialogue(player);
     getActions(player.getState(), actions);
     var encounterSummary = getEncounterSummary();
     var playerDto = PlayerDto.from(player);
@@ -152,7 +153,7 @@ public class WebGame {
         actions.stream()
             .filter(a -> a.getIndex() == choice)
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("Action does not exist"));
+            .orElseThrow(() -> new GenericWebException("Action does not exist"));
     action.execute(player);
   }
 

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/WebGame.java
@@ -136,13 +136,16 @@ public class WebGame {
   }
 
   private List<String> getInteractions(List<String> interactions) {
-    while (player.getCurrentEvent().hasCurrentInteraction()) {
-      interactions.add(
-          player.getCurrentEvent().getCurrentInteraction().getText().replaceAll(ESCAPE_CHARS, ""));
-      if (!player.getCurrentEvent().getCurrentActions().isEmpty()) {
+    var currentEvent = player.getCurrentEvent();
+    while (currentEvent.hasCurrentInteraction()) {
+      interactions.add(currentEvent.getCurrentInteraction().getText().replaceAll(ESCAPE_CHARS, ""));
+      if (!currentEvent.getCurrentActions().isEmpty()) {
         break;
       }
-      player.getCurrentEvent().progressDialogue();
+      currentEvent.progressDialogue();
+    }
+    if (currentEvent.isRepeatable() && !currentEvent.hasCurrentInteraction()) {
+      currentEvent.resetDialogue();
     }
     return interactions;
   }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/dto/WebResponse.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/dto/WebResponse.java
@@ -20,9 +20,13 @@ public record WebResponse(
         player);
   }
 
-  public WebResponse(List<Action> actions, EncounterSummaryDto encounterSummary, PlayerDto player) {
+  public WebResponse(
+      List<Action> actions,
+      EncounterSummaryDto encounterSummary,
+      PlayerDto player,
+      WebViewType viewType) {
     this(
-        WebViewType.ENCOUNTER_SUMMARY,
+        viewType,
         actions.stream().map(ActionResponseDto::from).toList(),
         encounterSummary,
         null,
@@ -41,6 +45,7 @@ public record WebResponse(
   public enum WebViewType {
     DEFAULT,
     ENCOUNTER_SUMMARY,
-    DIALOGUE
+    DIALOGUE,
+    GAME_OVER
   }
 }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/InGameException.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/InGameException.java
@@ -4,19 +4,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class GenericWebException extends RuntimeException {
+public class InGameException extends RuntimeException {
 
   private final HttpStatus status;
-  private static final WebErrorType errorType = WebErrorType.GENERIC;
+  private static final WebErrorType errorType = WebErrorType.IN_GAME;
 
-  public GenericWebException(String s) {
+  public InGameException(String s) {
     super(s);
     status = HttpStatus.BAD_REQUEST;
-  }
-
-  public GenericWebException(String s, HttpStatus status) {
-    super(s);
-    this.status = status;
   }
 
   public WebErrorType getErrorType() {

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/RestExceptionHandler.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/RestExceptionHandler.java
@@ -16,17 +16,28 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = {IllegalArgumentException.class, IllegalStateException.class})
   protected ResponseEntity<Object> handleIllegalArgumentOrState(
       RuntimeException ex, WebRequest request) {
-    var bodyOfResponse = new ErrorResponse(ex.getMessage());
-    return handleExceptionInternal(
-        ex, bodyOfResponse, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    var body = new ErrorResponse(ex.getMessage());
+    return handleExceptionInternal(ex, body, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
 
   @ExceptionHandler(value = {GenericWebException.class})
   protected ResponseEntity<Object> handleGenericWebException(
-      RuntimeException ex, WebRequest request) {
+      GenericWebException ex, WebRequest request) {
     log.info("GenericWebException: " + ex.getMessage());
-    return handleIllegalArgumentOrState(ex, request);
+    var body = new ErrorResponse(ex.getErrorType(), ex.getMessage());
+    return handleExceptionInternal(ex, body, new HttpHeaders(), ex.getStatus(), request);
   }
 
-  public record ErrorResponse(String errorMessage) {}
+  @ExceptionHandler(value = {InGameException.class})
+  protected ResponseEntity<Object> handleInGameException(InGameException ex, WebRequest request) {
+    log.debug("InGameException: " + ex.getMessage());
+    var body = new ErrorResponse(ex.getErrorType(), ex.getMessage());
+    return handleExceptionInternal(ex, body, new HttpHeaders(), ex.getStatus(), request);
+  }
+
+  public record ErrorResponse(WebErrorType errorType, String errorMessage) {
+    public ErrorResponse(String errorMessage) {
+      this(WebErrorType.UNHANDLED, errorMessage);
+    }
+  }
 }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/RestExceptionHandler.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/RestExceptionHandler.java
@@ -16,7 +16,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = {IllegalArgumentException.class, IllegalStateException.class})
   protected ResponseEntity<Object> handleIllegalArgumentOrState(
       RuntimeException ex, WebRequest request) {
-    var bodyOfResponse = ex.getMessage();
+    var bodyOfResponse = new ErrorResponse(ex.getMessage());
     return handleExceptionInternal(
         ex, bodyOfResponse, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
   }
@@ -27,4 +27,6 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     log.info("GenericWebException: " + ex.getMessage());
     return handleIllegalArgumentOrState(ex, request);
   }
+
+  public record ErrorResponse(String errorMessage) {}
 }

--- a/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/WebErrorType.java
+++ b/src/main/java/com/hindsight/king_of_castrop_rauxel/web/exception/WebErrorType.java
@@ -1,0 +1,7 @@
+package com.hindsight.king_of_castrop_rauxel.web.exception;
+
+public enum WebErrorType {
+  GENERIC,
+  IN_GAME,
+  UNHANDLED
+}


### PR DESCRIPTION
Improved MVP web game loop:

- Improved error handling with error type (`IN_GAME`, `GENERIC`, `UNHANDLED`) and message
- Handle player death
- Remove ANSI escape characters from actions and interactions
- Added ability to resume an active game
- Filter out available dialogues (which are reset repeatable events) from quest log endpoint

Bugfixes:
- Fixed bug that left game in unrecoverable state when entering one-line dialogues with no actions
- Fixed bug where one-line dialogues would not reset once completed